### PR TITLE
[DO NOT MERGE] Enable link-time optimization

### DIFF
--- a/Atmel/Device_Startup/startup_samd51.c
+++ b/Atmel/Device_Startup/startup_samd51.c
@@ -235,7 +235,7 @@ void SDHC1_Handler           ( void ) __attribute__ ((weak, alias("Dummy_Handler
 #endif
 
 /* Exception Table */
-__attribute__ ((section(".vectors")))
+__attribute__ ((section(".vectors" ), used))
 const DeviceVectors exception_table = {
 
         /* Configure Initial Stack Pointer, using linker-generated symbols */

--- a/Atmel/hal/utils/src/utils_syscalls.c
+++ b/Atmel/hal/utils/src/utils_syscalls.c
@@ -57,6 +57,7 @@ extern int     _getpid(void);
 /**
  * \brief Replacement of C library of _sbrk
  */
+__attribute__((used))
 extern caddr_t _sbrk(int incr)
 {
 	static unsigned char *heap = NULL;
@@ -75,6 +76,7 @@ extern caddr_t _sbrk(int incr)
 /**
  * \brief Replacement of C library of link
  */
+ __attribute__((used))
 extern int link(char *old, char *_new)
 {
 	(void)old, (void)_new;
@@ -84,6 +86,7 @@ extern int link(char *old, char *_new)
 /**
  * \brief Replacement of C library of _close
  */
+ __attribute__((used))
 extern int _close(int file)
 {
 	(void)file;
@@ -93,6 +96,7 @@ extern int _close(int file)
 /**
  * \brief Replacement of C library of _fstat
  */
+ __attribute__((used))
 extern int _fstat(int file, struct stat *st)
 {
 	(void)file;
@@ -104,6 +108,7 @@ extern int _fstat(int file, struct stat *st)
 /**
  * \brief Replacement of C library of _isatty
  */
+ __attribute__((used))
 extern int _isatty(int file)
 {
 	(void)file;
@@ -113,6 +118,7 @@ extern int _isatty(int file)
 /**
  * \brief Replacement of C library of _lseek
  */
+ __attribute__((used))
 extern int _lseek(int file, int ptr, int dir)
 {
 	(void)file, (void)ptr, (void)dir;
@@ -122,10 +128,10 @@ extern int _lseek(int file, int ptr, int dir)
 /**
  * \brief Replacement of C library of _exit
  */
+ __attribute__((used))
 extern void _exit(int status)
 {
-	printf("Exiting with status %d.\n", status);
-
+    (void) status;
 	for (;;)
 		;
 }
@@ -133,6 +139,7 @@ extern void _exit(int status)
 /**
  * \brief Replacement of C library of _kill
  */
+ __attribute__((used))
 extern void _kill(int pid, int sig)
 {
 	(void)pid, (void)sig;
@@ -142,6 +149,7 @@ extern void _kill(int pid, int sig)
 /**
  * \brief Replacement of C library of _getpid
  */
+ __attribute__((used))
 extern int _getpid(void)
 {
 	return -1;

--- a/main.c
+++ b/main.c
@@ -6,6 +6,15 @@
 
 static TaskHandle_t xRRRC_Main_xTask;
 
+/**
+ * Put functions here to prevent Link-time optimization to remove them
+ */
+__attribute__((used,optimize("O0")))
+void ltoFunctionKeeper(void)
+{
+    vTaskSwitchContext();
+}
+
 int main(void)
 {
     RRRC_ProcessLogic_Init();
@@ -52,7 +61,8 @@ void assert_failed(const char *file, uint32_t line)
 }
 
 /* Cortex-M4 core handlers */
-void prvGetRegistersFromStack( uint32_t *pulFaultStackAddress )
+__attribute__((used))
+static void prvGetRegistersFromStack( uint32_t *pulFaultStackAddress )
 {
     /* These are volatile to try and prevent the compiler/linker optimising them
     away as the variables never actually get used. If the debugger won't show the

--- a/rrrc_samd51.cproj
+++ b/rrrc_samd51.cproj
@@ -218,11 +218,13 @@
 </ArmGcc>
     </ToolchainSettings>
     <UsesExternalMakeFile>True</UsesExternalMakeFile>
-    <OutputDirectory>C:\_RevolutionRobotics\Firmware</OutputDirectory>
+    <OutputDirectory>C:\_RevolutionRobotics\Sw\Firmware</OutputDirectory>
     <BuildTarget>all --jobs 16 --output-sync --ignore-errors --silent</BuildTarget>
     <CleanTarget>clean</CleanTarget>
-    <ExternalMakeFilePath>C:\_RevolutionRobotics\Firmware\Makefile</ExternalMakeFilePath>
-    <PreBuildEvent>python -m tools.generate_makefile
+    <ExternalMakeFilePath>C:\_RevolutionRobotics\Sw\Firmware\Makefile</ExternalMakeFilePath>
+    <PreBuildEvent>venv\scripts\activate.bat
+python -m tools.generate_makefile
+
 python -m tools.gen_version</PreBuildEvent>
     <PostBuildEvent>python -m tools.prepare --build-dir=Release --out=output
 cp Release/rrrc_samd51.elf rrrc_samd51.elf</PostBuildEvent>

--- a/tools/generate_makefile.py
+++ b/tools/generate_makefile.py
@@ -22,6 +22,7 @@ INCLUDE_PATHS += \\
 {{/ includes }}
 
 COMPILE_FLAGS += \\
+-flto \\
 -x c \\
 -mthumb \\
 -D__SAMD51P19A__ \\
@@ -84,7 +85,7 @@ $(OUTPUT_DIR)/%.o: %.c
 
 $(OUTPUT_FILE).elf: $(OBJS)
 \t@echo Building target: $@
-\t$(GCC_BINARY_PREFIX)arm-none-eabi-gcc$(GCC_BINARY_SUFFIX) -o$(OUTPUT_FILE).elf $(OBJS) -mthumb -Wl,-Map=$(OUTPUT_FILE).map --specs=nano.specs -Wl,--start-group -lm  -Wl,--end-group $(LINK_DIRS) -Wl,--gc-sections -mcpu=cortex-m4 -TAtmel/Device_Startup/samd51p19a_flash.ld
+\t$(GCC_BINARY_PREFIX)arm-none-eabi-gcc$(GCC_BINARY_SUFFIX) -o$(OUTPUT_FILE).elf $(OBJS) -flto -mthumb -Wl,-Map=$(OUTPUT_FILE).map --specs=nano.specs -Wl,--start-group -lm  -Wl,--end-group $(LINK_DIRS) -Wl,--gc-sections -mcpu=cortex-m4 -TAtmel/Device_Startup/samd51p19a_flash.ld
 \t@echo Finished building target: $@
 \t$(GCC_BINARY_PREFIX)arm-none-eabi-objcopy$(GCC_BINARY_SUFFIX) -O binary $(OUTPUT_FILE).elf $(OUTPUT_FILE).bin
 \t$(GCC_BINARY_PREFIX)arm-none-eabi-objcopy$(GCC_BINARY_SUFFIX) -O ihex -R .eeprom -R .fuse -R .lock -R .signature  $(OUTPUT_FILE).elf $(OUTPUT_FILE).hex


### PR DESCRIPTION
This change should allow the linker to optimize between translation units, thus remove a lot of overhead e.g. in the integration code.

Result is -9K binary size, most functions get inlined