### PR TITLE
Feature/func arg direction

### DIFF
--- a/rrrc/components/MemoryAllocator/config.json
+++ b/rrrc/components/MemoryAllocator/config.json
@@ -7,13 +7,13 @@
         "Allocate": {
             "return_type": "void*",
             "arguments": {
-                "size": "size_t"
+                "size": {"data_type": "size_t", "direction": "in"}
             }
         },
         "Free": {
             "return_type": "void",
             "arguments": {
-                "ptr": "void**"
+                "ptr": {"data_type": "void*", "direction": "inout"}
             }
         }
     },

--- a/rrrc/components/MotorPortHandler/config.json
+++ b/rrrc/components/MotorPortHandler/config.json
@@ -51,14 +51,14 @@
             "port_type": "ServerCall",
             "return_type": "void*",
             "arguments": {
-                "size": "size_t"
+                "size": {"data_type": "size_t", "direction": "in"}
             }
         },
         "Free": {
             "port_type": "ServerCall",
             "return_type": "void",
             "arguments": {
-                "ptr": "void**"
+                "ptr": {"data_type": "void*", "direction": "inout"}
             }
         },
         "DriveStrength": {

--- a/rrrc/components/SensorPortHandler/config.json
+++ b/rrrc/components/SensorPortHandler/config.json
@@ -22,14 +22,14 @@
             "port_type": "ServerCall",
             "return_type": "void*",
             "arguments": {
-                "size": "size_t"
+                "size": {"data_type": "size_t", "direction": "in"}
             }
         },
         "Free": {
             "port_type": "ServerCall",
             "return_type": "void",
             "arguments": {
-                "ptr": "void**"
+                "ptr": {"data_type": "void*", "direction": "inout"}
             }
         },
         "ReadCurrentTicks": {

--- a/tools/plugins/BuiltinDataTypes.py
+++ b/tools/plugins/BuiltinDataTypes.py
@@ -811,7 +811,7 @@ port_type_data = {
             },
             'pointer': lambda types, port_data: {
                 'return_type':    'void',
-                'arguments':      {'value': '{}*'.format(port_data['data_type'])},
+                'arguments':      {'value': {'direction': 'out', 'data_type': port_data['data_type']}},
                 'used_arguments': ['value'],
                 'asserts':        'value != NULL',
                 'body':           '*value = {};'.format(get_default_value_formatted(types, port_data))
@@ -830,13 +830,12 @@ port_type_data = {
             'common':  lambda types, port_data: {
                 'attributes':        ['weak'],
                 'return_type':       'QueueStatus_t',
-                'func_name_pattern': '{}_Read_{}'
+                'func_name_pattern': '{}_Read_{}',
+                'arguments':      {'value': {'direction': 'out', 'data_type': port_data['data_type']}}
             },
             'value':   lambda types, port_data: {
-                'arguments': {'value': '{}*'.format(port_data['data_type'])},
             },
             'pointer': lambda types, port_data: {
-                'arguments':      {'value': '{}*'.format(port_data['data_type'])},
                 'asserts':        'value != NULL',
                 'used_arguments': ['value']
             }
@@ -860,7 +859,7 @@ port_type_data = {
             },
             'value':   lambda types, port_data: {
                 'return_type':    port_data['data_type'],
-                'arguments':      {'index': 'uint32_t'},
+                'arguments':      {'index': {'direction':'in', 'data_type': 'uint32_t'}},
                 'return_value':   get_default_value(types, port_data),
                 'asserts':        'index < {}'.format(port_data['count']),
                 'used_arguments': ['index'],
@@ -868,8 +867,8 @@ port_type_data = {
             'pointer': lambda types, port_data: {
                 'return_type':    'void',
                 'arguments':      {
-                    'index': 'uint32_t',
-                    'value': '{}*'.format(port_data['data_type'])
+                    'index': {'direction':'in', 'data_type': 'uint32_t'},
+                    'value': {'direction': 'out', 'data_type': port_data['data_type']},
                 },
                 'asserts':        [
                     'index < {}'.format(port_data['count']),
@@ -895,10 +894,10 @@ port_type_data = {
                 'return_type':       'void'
             },
             'value':   lambda types, port_data: {
-                'arguments': {'value': 'const {}'.format(port_data['data_type'])}
+                'arguments': {'value': {'direction': 'in', 'data_type': port_data['data_type']}},
             },
             'pointer': lambda types, port_data: {
-                'arguments':      {'value': 'const {}*'.format(port_data['data_type'])},
+                'arguments':      {'value': {'direction': 'in', 'data_type': port_data['data_type']}},
                 'asserts':        'value != NULL',
                 'used_arguments': ['value']
             }
@@ -916,20 +915,16 @@ port_type_data = {
             'common':  lambda types, port_data: {
                 'attributes':        ['weak'],
                 'func_name_pattern': '{}_Write_{}',
-                'return_type':       'void'
+                'return_type':       'void',
+                'arguments': {
+                    'index': {'direction':'in', 'data_type': 'uint32_t'},
+                    'value': {'direction': 'in', 'data_type': port_data['data_type']}
+                }
             },
             'value':   lambda types, port_data: {
-                'arguments': {
-                    'index': 'uint32_t',
-                    'value': 'const {}'.format(port_data['data_type'])
-                },
                 'asserts':   'index < {}'.format(port_data['count']),
             },
             'pointer': lambda types, port_data: {
-                'arguments':      {
-                    'index': 'uint32_t',
-                    'value': 'const {}*'.format(port_data['data_type'])
-                },
                 'used_arguments': ['value'],
                 'asserts':        [
                     'index < {}'.format(port_data['count']),
@@ -957,7 +952,9 @@ port_type_data = {
             },
             'pointer': lambda types, port_data: {
                 'return_type':    'void',
-                'arguments':      {'value': '{}*'.format(port_data['data_type'])},
+                'arguments':      {
+                    'value': {'direction': 'out', 'data_type': port_data['data_type']}
+                },
                 'body':           '*value = {};'.format(types.render_value(port_data['data_type'], port_data['value'])),
                 'asserts':        'value != NULL',
                 'used_arguments': ['value']
@@ -977,7 +974,7 @@ port_type_data = {
             'value':   lambda types, port_data: {
                 'return_type':  port_data['data_type'],
                 'arguments':    {
-                    'index': 'uint32_t'
+                    'index': {'direction': 'in', 'data_type': 'uint32_t'}
                 },
                 'body':         'static const {} data[{}] = {{ {} }};'.format(port_data['data_type'],
                                                                               port_data['count'],
@@ -987,8 +984,8 @@ port_type_data = {
             'pointer': lambda types, port_data: {
                 'return_type':    'void',
                 'arguments':      {
-                    'index': 'uint32_t',
-                    'value': '{}*'.format(port_data['data_type'])
+                    'index': {'direction': 'in', 'data_type': 'uint32_t'},
+                    'value': {'direction': 'out', 'data_type': port_data['data_type']}
                 },
                 'used_arguments': ['value', 'index'],
                 'body':           'static const {} data[{}] = {{ {} }};\n'

--- a/tools/plugins/RuntimeEvents.py
+++ b/tools/plugins/RuntimeEvents.py
@@ -20,7 +20,10 @@ def collect_arguments(attributes, consumer_name, consumer_arguments, function):
         if arg_name in user_arguments:
             passed_arguments[arg_name] = user_arguments[arg_name]
         elif arg_name in function.arguments:
-            if arg_type != function.arguments[arg_name]['data_type']:
+            if type(arg_type) is str:
+                arg_type = {'direction': 'in', 'data_type': arg_type}
+
+            if arg_type != function.arguments[arg_name]:
                 raise Exception(
                     'Caller of {} has matching argument {} but types are different'.format(consumer_name, arg_name))
             passed_arguments[arg_name] = arg_name
@@ -59,7 +62,7 @@ class EventSignal(SignalType):
             'data':     {
                 'component': component_name,
                 'runnable':  port_name,
-                'arguments': ', '.join([str(v) for k, v in passed_arguments.items()])
+                'arguments': ', '.join([str(v) for v in passed_arguments.values()])
             }
         }
 

--- a/tools/plugins/RuntimeEvents.py
+++ b/tools/plugins/RuntimeEvents.py
@@ -20,7 +20,7 @@ def collect_arguments(attributes, consumer_name, consumer_arguments, function):
         if arg_name in user_arguments:
             passed_arguments[arg_name] = user_arguments[arg_name]
         elif arg_name in function.arguments:
-            if arg_type != function.arguments[arg_name]:
+            if arg_type != function.arguments[arg_name]['data_type']:
                 raise Exception(
                     'Caller of {} has matching argument {} but types are different'.format(consumer_name, arg_name))
             passed_arguments[arg_name] = arg_name

--- a/tools/runtime.py
+++ b/tools/runtime.py
@@ -160,7 +160,6 @@ class FunctionDescriptor:
 
     def get_header(self):
         def generate_parameter(name, data):
-            arg_type = data['data_type']
 
             try:
                 pass_by_ptr = self._types.get(data['data_type'])['pass_semantic'] == TypeCollection.PASS_BY_POINTER
@@ -180,7 +179,7 @@ class FunctionDescriptor:
                     'inout': '{}* {}'
                 },
                 'value': {
-                    'in': 'const {} {}',
+                    'in': '{} {}',
                     'out': '{}* {}',
                     'inout': '{}* {}'
                 }

--- a/tools/runtime.py
+++ b/tools/runtime.py
@@ -129,7 +129,7 @@ class FunctionDescriptor:
             self._asserts.add('ASSERT({});'.format(statements))
         else:
             for statement in statements:
-                self._asserts.add('ASSERT({});'.format(statement))
+                self.add_input_assert(statement)
 
     def add_body(self, body):
         if type(body) is str:


### PR DESCRIPTION
Mark port function arguments as in, out or inout. Generate code based on this information and fix void** arguments (which are void*, but inout args technically, because the pointer itself is written by the callee)