### PR TITLE
Make sure types are generated in order of dependency

### DIFF
--- a/tools/generator_common.py
+++ b/tools/generator_common.py
@@ -224,18 +224,6 @@ def copy(src, required, optional):
     return dst
 
 
-def unique(values: list):
-    """Removes duplicates from the input list
-
-    >>> unique(['a', 'b', 'a', 'a', 'c', 'b', 'd'])
-    ['a', 'b', 'c', 'd']"""
-    unique_values = []
-    for value in values:
-        if value not in unique_values:
-            unique_values.append(value)
-    return unique_values
-
-
 def delete(path):
     try:
         os.remove(path)

--- a/tools/plugins/RuntimeEvents.py
+++ b/tools/plugins/RuntimeEvents.py
@@ -95,7 +95,7 @@ class ServerCallSignal(SignalType):
         data = {
             'component': component_name,
             'runnable':  port_name,
-            'arguments': ', '.join([str(v) for k, v in passed_arguments.items()]),
+            'arguments': ', '.join([str(v) for v in passed_arguments.values()]),
             'data_type': consumer_port_data['return_type']
         }
 


### PR DESCRIPTION
Random typedef order can lead to types depending on not-yet-defined other types